### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,9 +34,9 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
     
     - name: Install Postman CLI
       shell: bash


### PR DESCRIPTION
Updating uses: actions/setup-node@v4 to uses: actions/setup-node@v6 and Node 20 to Node 24, because GitHub Actions has migrated hosted runners to Node 24.